### PR TITLE
Add device specific actions

### DIFF
--- a/device-specific/back-or-done.yaml
+++ b/device-specific/back-or-done.yaml
@@ -1,0 +1,15 @@
+appId: ${APP_ID}
+
+---
+
+- runFlow:
+    when:
+      platform: Android
+    commands:
+      - back
+
+- runFlow:
+    when:
+      platform: iOS
+    commands:
+      - tapOn: "Done"

--- a/topics/edit-initial-topics.yaml
+++ b/topics/edit-initial-topics.yaml
@@ -71,4 +71,4 @@ appId: ${APP_ID}
 - tapOn:
     id: "toggle Travel abroad"
 
-- back
+- runFlow: ../device-specific/back-or-done.yaml


### PR DESCRIPTION
Make it possible to have short-term platform specific commands, sub-flows or actions. Ideally, these should not exist. Pragmatically, they will have to.