### PR TITLE
Android APP_ID being rename in-line with iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,18 +71,18 @@ adb install app/build/outputs/apk/debug/app-debug.apk
 
 Now that you have a running simulator that has your app installed on it, you can run the tests.
 
-Note that we are passing in an environment variable below as the `appId` that is required by Maestro to identify the app to start. This differs between the iOS and Android implementation of the GOV.UK app. For Android it is: `uk.govuk.app.dev`, and for iOS it is: `uk.gov.govuk.dev`.
+Note that we are passing in an environment variable below as the `appId` that is required by Maestro to identify the app to start. This differs between the iOS and Android implementation of the GOV.UK app.
 
 ```shell
 cd /dir/where/your/tests/are
 
-maestro test -e APP_ID=<see above> filename.yaml
+maestro test filename.yaml
 ```
 
 You can also run tests by tag(s). For example:
 
 ```shell
-maestro test -e APP_ID=<see above> --include-tags=<tag-name>(,tag-name) flows
+maestro test --include-tags=<tag-name>(,tag-name) flows
 ```
 
 ## Other useful Maestro commands

--- a/flows/device-specific/Android/edit-initial-topics-android.yaml
+++ b/flows/device-specific/Android/edit-initial-topics-android.yaml
@@ -1,4 +1,4 @@
-appId: ${APP_ID}
+appId: uk.gov.govuk.dev
 
 ---
 

--- a/flows/device-specific/back-or-done.yaml
+++ b/flows/device-specific/back-or-done.yaml
@@ -1,4 +1,4 @@
-appId: ${APP_ID}
+appId: uk.gov.govuk.dev
 
 ---
 

--- a/flows/device-specific/edit-initial-topics.yaml
+++ b/flows/device-specific/edit-initial-topics.yaml
@@ -1,4 +1,4 @@
-appId: ${APP_ID}
+appId: uk.gov.govuk.dev
 
 ---
 

--- a/flows/device-specific/iOS/edit-initial-topics-ios.yaml
+++ b/flows/device-specific/iOS/edit-initial-topics-ios.yaml
@@ -1,4 +1,4 @@
-appId: ${APP_ID}
+appId: uk.gov.govuk.dev
 
 ---
 

--- a/flows/device-specific/share-app-usage-toggle-checked.yaml
+++ b/flows/device-specific/share-app-usage-toggle-checked.yaml
@@ -1,4 +1,4 @@
-appId: ${APP_ID}
+appId: uk.gov.govuk.dev
 
 ---
 

--- a/flows/onboarding-select-topics.yaml
+++ b/flows/onboarding-select-topics.yaml
@@ -1,4 +1,4 @@
-appId: ${APP_ID}
+appId: uk.gov.govuk.dev
 
 tags:
   - end-to-end

--- a/flows/onboarding-skip-topics.yaml
+++ b/flows/onboarding-skip-topics.yaml
@@ -1,4 +1,4 @@
-appId: ${APP_ID}
+appId: uk.gov.govuk.dev
 
 tags:
   - end-to-end

--- a/flows/onboarding/accept-statistics-sharing.yaml
+++ b/flows/onboarding/accept-statistics-sharing.yaml
@@ -1,4 +1,4 @@
-appId: ${APP_ID}
+appId: uk.gov.govuk.dev
 
 ---
 

--- a/flows/onboarding/view-all-screens.yaml
+++ b/flows/onboarding/view-all-screens.yaml
@@ -1,4 +1,4 @@
-appId: ${APP_ID}
+appId: uk.gov.govuk.dev
 
 ---
 

--- a/flows/returning-user-can-edit-topics.yaml
+++ b/flows/returning-user-can-edit-topics.yaml
@@ -1,4 +1,4 @@
-appId: ${APP_ID}
+appId: uk.gov.govuk.dev
 
 tags:
   - end-to-end

--- a/flows/returning-user-selected-topics-and-analytics-pref-persisted.yaml
+++ b/flows/returning-user-selected-topics-and-analytics-pref-persisted.yaml
@@ -1,4 +1,4 @@
-appId: ${APP_ID}
+appId: uk.gov.govuk.dev
 
 tags:
   - end-to-end

--- a/flows/settings/validate-analytics-preference-selected.yaml
+++ b/flows/settings/validate-analytics-preference-selected.yaml
@@ -1,4 +1,4 @@
-appId: ${APP_ID}
+appId: uk.gov.govuk.dev
 
 ---
 

--- a/flows/topics/select-initial-topics.yaml
+++ b/flows/topics/select-initial-topics.yaml
@@ -1,4 +1,4 @@
-appId: ${APP_ID}
+appId: uk.gov.govuk.dev
 
 ---
 

--- a/flows/topics/skip-initial-topics-selection.yaml
+++ b/flows/topics/skip-initial-topics-selection.yaml
@@ -1,4 +1,4 @@
-appId: ${APP_ID}
+appId: uk.gov.govuk.dev
 
 ---
 

--- a/flows/topics/validate-all-topics.yaml
+++ b/flows/topics/validate-all-topics.yaml
@@ -1,4 +1,4 @@
-appId: ${APP_ID}
+appId: uk.gov.govuk.dev
 
 ---
 

--- a/flows/topics/validate-edited-topics.yaml
+++ b/flows/topics/validate-edited-topics.yaml
@@ -1,4 +1,4 @@
-appId: ${APP_ID}
+appId: uk.gov.govuk.dev
 
 ---
 

--- a/flows/topics/validate-initial-topics.yaml
+++ b/flows/topics/validate-initial-topics.yaml
@@ -1,4 +1,4 @@
-appId: ${APP_ID}
+appId: uk.gov.govuk.dev
 
 ---
 


### PR DESCRIPTION
The Android app id has been updated to be the same as iOS - `uk.gov.govuk` - so we can now dispense with the need for the environment variable and simply hard-code is in - at least for now.